### PR TITLE
Add asc as known mime type

### DIFF
--- a/workers/src/files.ts
+++ b/workers/src/files.ts
@@ -9,6 +9,7 @@ const knownMimeTypes = new Map([
   [".sha1", "text/plain"],
   [".sha256", "text/plain"],
   [".sha512", "text/plain"],
+  [".asc", "text/plain"],
 ]);
 
 export function getMimeType(filePath: string, typeInBucket?: string): string {

--- a/workers/test/files.test.ts
+++ b/workers/test/files.test.ts
@@ -12,6 +12,7 @@ describe.concurrent("file mime type", () => {
     sha1: "text/plain",
     sha256: "text/plain",
     sha512: "text/plain",
+    asc: "text/plain",
     hoge: "application/octet-stream",
   };
   for (const [key, value] of Object.entries(pairs)) {

--- a/workers/test/files.test.ts
+++ b/workers/test/files.test.ts
@@ -49,4 +49,8 @@ describe.concurrent("available path", () => {
     const path = file.availablePaths(["com.kotori316", "org.kotori316"]).prefixes;
     expect(path).toEqual(["com/kotori316/", "org/kotori316/"]);
   });
+  it("prefix of com", async () => {
+    const path = file.availablePaths(["com"]).prefixes;
+    expect(path).toEqual(["com/"]);
+  });
 });


### PR DESCRIPTION
To see the signature of artifacts, allow accessing the data without downloading the file